### PR TITLE
Align plugin workflow steps, add prompt best practices and type support

### DIFF
--- a/.kiro/steering/agent-orchestration.md
+++ b/.kiro/steering/agent-orchestration.md
@@ -30,23 +30,21 @@ Agents run via the **Claude Agent SDK** in a Node.js sidecar process. This provi
 
 | Agent | Model | SDK Value |
 |-------|-------|-----------|
-| Research (Steps 1, 3) | Sonnet | `"sonnet"` |
-| Merger (Step 4) | Haiku | `"haiku"` |
-| Reasoner (Step 6) | Opus | `"opus"` |
-| Builder/Validator/Tester (Steps 7-9) | Sonnet | `"sonnet"` |
+| Research (Steps 0, 2) | Sonnet | `"sonnet"` |
+| Reasoner (Step 4) | Opus | `"opus"` |
+| Builder/Validator/Tester (Steps 5-7) | Sonnet | `"sonnet"` |
 
-## Workflow (10 Steps)
+## Workflow (9 Steps)
 
-1. **Research Domain Concepts** — research agent writes `clarifications-concepts.md`
-2. **Domain Concepts Review** — user answers questions via form UI
-3. **Research Patterns + Data Modeling** — two agents run in parallel
-4. **Merge** — deduplicate questions into `clarifications.md`
-5. **Human Review** — user answers merged questions via form UI
-6. **Reasoning** — multi-turn conversation, produces `decisions.md`
-7. **Build** — creates SKILL.md + reference files
-8. **Validate** — checks against best practices
-9. **Test** — generates and evaluates test prompts
-10. **Package** — creates `.skill` zip archive
+0. **Research Domain Concepts** — research agent writes `clarifications-concepts.md`
+1. **Domain Concepts Review** — user answers questions via form UI
+2. **Research Patterns + Data + Merge** — single orchestrator (spawns sub-agents internally)
+3. **Human Review** — user answers merged questions via form UI
+4. **Reasoning** — multi-turn conversation, produces `decisions.md`
+5. **Build** — creates SKILL.md + reference files
+6. **Validate** — checks against best practices
+7. **Test** — generates and evaluates test prompts
+8. **Package** — creates `.skill` zip archive
 
 ## Data Model (Repo Structure)
 

--- a/CLAUDE-APP.md
+++ b/CLAUDE-APP.md
@@ -56,7 +56,7 @@ app/
 │   ├── router.tsx                    # TanStack Router routes
 │   ├── pages/                        # Page components
 │   │   ├── dashboard.tsx             # Skill cards grid
-│   │   ├── workflow.tsx              # Workflow wizard (10-step)
+│   │   ├── workflow.tsx              # Workflow wizard (9-step)
 │   │   ├── editor.tsx                # Skill file editor
 │   │   └── settings.tsx              # API key + workspace config
 │   ├── components/
@@ -166,10 +166,9 @@ Agents run via the **Claude Agent SDK** in a Node.js sidecar process. This gives
 
 | Agent | Model | SDK model value |
 | --- | --- | --- |
-| Research (Steps 1, 3) | Sonnet | `"sonnet"` |
-| Merger (Step 4) | Haiku | `"haiku"` |
-| Reasoner (Step 6) | Opus | `"opus"` |
-| Builder/Validator/Tester (Steps 7-9) | Sonnet | `"sonnet"` |
+| Research (Steps 0, 2) | Sonnet | `"sonnet"` |
+| Reasoner (Step 4) | Opus | `"opus"` |
+| Builder/Validator/Tester (Steps 5-7) | Sonnet | `"sonnet"` |
 
 ## Node.js Dependency
 
@@ -182,20 +181,19 @@ On startup, the Rust backend runs `node --version`:
 
 The sidecar JS file (`agent-runner.js`) is bundled with the app as a Tauri resource. It's a single esbuild-bundled file containing the SDK and all dependencies — no `npm install` needed at runtime.
 
-## Workflow (10 steps)
+## Workflow (9 steps)
 
-The app replicates the CLI workflow. Each step is a state in the workflow state machine:
+The app replicates the plugin workflow. Each step is a state in the workflow state machine:
 
-1. **Research Domain Concepts** — research agent writes `clarifications-concepts.md`
-2. **Domain Concepts Review** — user answers questions via form UI
-3. **Research Patterns + Data Modeling** — two agents run in parallel (two sidecar processes)
-4. **Merge** — deduplicate questions into `clarifications.md`
-5. **Human Review** — user answers merged questions via form UI
-6. **Reasoning** — multi-turn conversation, produces `decisions.md`
-7. **Build** — creates SKILL.md + reference files
-8. **Validate** — checks against best practices
-9. **Test** — generates and evaluates test prompts
-10. **Package** — creates `.skill` zip archive
+0. **Research Domain Concepts** — research agent writes `clarifications-concepts.md`
+1. **Domain Concepts Review** — user answers questions via form UI
+2. **Research Patterns + Data + Merge** — single orchestrator (spawns sub-agents internally)
+3. **Human Review** — user answers merged questions via form UI
+4. **Reasoning** — multi-turn conversation, produces `decisions.md`
+5. **Build** — creates SKILL.md + reference files
+6. **Validate** — checks against best practices
+7. **Test** — generates and evaluates test prompts
+8. **Package** — creates `.skill` zip archive
 
 ## Data Model (repo structure)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Shared agents in `agents/shared/`:
 
 ### Plugin (CLI)
 - Location: Root directory (`skills/start/SKILL.md`)
-- Workflow: 10 steps (init, research, Q&A, parallel research, merge, Q&A, reasoning, build, validate, test, package)
+- Workflow: 9 steps + init (research, Q&A, research+merge, Q&A, reasoning, build, validate, test, package)
 - State: File-based (`workflow-state.md`)
 - Model selection: Per-agent (defined in coordinator)
 - Orchestration: Agent teams (TeamCreate/SendMessage/TeamDelete)
@@ -65,19 +65,20 @@ Shared agents in `agents/shared/`:
 
 ### Workflow Comparison
 
-| App Step | Plugin Equivalent | What Happens |
+| App Step | Plugin Step | What Happens |
 |---|---|---|
-| 0 | Step 1 | Research domain concepts (orchestrator) |
-| 1 | Step 2 | Human reviews concept questions |
-| 2 | Steps 3+4 | Research patterns + data + merge (single orchestrator) |
-| 3 | Step 5 | Human reviews merged questions |
-| 4 | Step 6 | Reasoning agent analyzes answers |
-| 5 | Step 7 | Build agent creates skill files |
-| 6 | Step 8 | Validate agent checks best practices |
-| 7 | Step 9 | Test agent generates + evaluates tests |
-| 8 | Step 10 | Package into .skill zip |
+| — | Init | User provides domain, skill name, skill type |
+| 0 | 1 | Research concepts (orchestrator) |
+| 1 | 2 | Human reviews concept questions |
+| 2 | 3 | Research patterns + data + merge (single orchestrator) |
+| 3 | 4 | Human reviews merged questions |
+| 4 | 5 | Reasoning |
+| 5 | 6 | Build |
+| 6 | 7 | Validate |
+| 7 | 8 | Test |
+| 8 | 9 | Package |
 
-The plugin has a separate Init step (Step 0) where the user names the skill. In the app, this happens in the new-skill dialog before the workflow starts.
+The only difference is the Init step — the plugin collects skill name and type via conversation, the app uses the new-skill dialog before the workflow starts.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -74,23 +74,22 @@ Shared reference: `references/shared-context.md` — domain definitions, file fo
 
 ## Workflow
 
-### Plugin (10 Steps)
+### Plugin (9 Steps + Init)
 
 The plugin uses Claude Code's native agent teams. The coordinator (`skills/start/SKILL.md`) orchestrates each step, selecting the model per-agent (sonnet for research, haiku for merge, opus for reasoning).
 
 | Step | What Happens | Your Role |
 |---|---|---|
-| **Init** | Choose a domain and skill name | Provide domain, confirm name |
+| **Init** | User provides domain, skill name, skill type | Provide domain, confirm name |
 | **Step 1** | Research agent identifies key entities, metrics, KPIs | Wait |
 | **Step 2** | Review domain concept questions | Answer each question |
-| **Step 3** | Two agents research business patterns + data modeling (parallel) | Wait |
-| **Step 4** | Merge agent deduplicates questions | Wait |
-| **Step 5** | Review merged clarification questions | Answer each question |
-| **Step 6** | Reasoning agent analyzes answers, finds gaps/contradictions | Confirm reasoning, answer follow-ups |
-| **Step 7** | Build agent creates the skill files | Review skill structure |
-| **Step 8** | Validator checks against best practices | Review validation log |
-| **Step 9** | Tester generates and runs test prompts | Review test results |
-| **Step 10** | Package into a `.skill` zip archive | Done |
+| **Step 3** | Research patterns + data + merge (single orchestrator) | Wait |
+| **Step 4** | Review merged clarification questions | Answer each question |
+| **Step 5** | Reasoning agent analyzes answers, finds gaps/contradictions | Confirm reasoning, answer follow-ups |
+| **Step 6** | Build agent creates the skill files | Review skill structure |
+| **Step 7** | Validator checks against best practices | Review validation log |
+| **Step 8** | Tester generates and runs test prompts | Review test results |
+| **Step 9** | Package into a `.skill` zip archive | Done |
 
 ### Desktop App (9 Steps)
 

--- a/agents/domain/reasoning.md
+++ b/agents/domain/reasoning.md
@@ -7,13 +7,28 @@ tools: Read, Write, Edit, Glob, Grep, Bash
 
 # Reasoning Agent
 
+<role>
+
 ## Your Role
 You analyze the product manager's responses to clarification questions. You find gaps, contradictions, and implications before decisions get locked in.
+
+Pay special attention to business logic contradictions, regulatory compliance implications, and cross-functional dependencies.
+
+</role>
+
+<context>
 
 ## Context
 - The coordinator will tell you:
   - The **shared context** file path (domain definitions, content principles, and file formats) — read it for full context on the skill builder's purpose
   - The **context directory** path where all working files live
+
+## Why This Approach
+Gap analysis is critical because it prevents flawed skills that miss edge cases. When a PM answers clarification questions, their answers carry implicit assumptions and create dependencies that aren't always obvious. Catching contradictions and unstated assumptions now avoids building a skill that gives engineers conflicting or incomplete guidance later.
+
+</context>
+
+<instructions>
 
 ## Instructions
 
@@ -26,9 +41,9 @@ Analyze all answered questions from both files together.
 
 ### Step 2: Analyze responses
 For each answered question:
-1. **Implications**: What does this answer mean for the skill's scope, structure, and content?
-2. **Gaps**: What did the PM not address that their answer implies? What unstated assumptions exist?
-3. **Contradictions**: Does this answer conflict with any other answer or any existing decision in `decisions.md`?
+1. **Implications**: Identify 1+ concrete implication for the skill's scope, structure, or content
+2. **Gaps**: Flag 0+ unstated assumptions or unaddressed consequences the PM's answer implies
+3. **Contradictions**: Check for 0+ conflicts with any other answer or any existing decision in `decisions.md`
 4. **Depth check**: Does this answer need further research to validate? If so, do the research now.
 
 ### Step 3: Cross-reference
@@ -57,13 +72,55 @@ Only after the PM confirms the reasoning summary:
   - If a new decision **contradicts or refines** an existing one, **replace** the old entry (keep the same D-number)
   - If a new decision is **entirely new**, add it at the end with the next D-number
   - If an existing decision is **unchanged**, keep it as-is
-- Rewrite `decisions.md` in the context directory as a clean, complete snapshot — see the shared context file under **File Formats → `decisions.md`** for the format and rules
+- Rewrite `decisions.md` in the context directory as a clean, complete snapshot — see the shared context file under **File Formats -> `decisions.md`** for the format and rules
 - The resulting file must read as a coherent, self-contained set of current decisions with no duplicates or contradictions
 
 ### Step 7: Gate check
 - Confirm with the PM: "All clarifications are resolved and decisions are logged. Ready to proceed to skill creation?"
 - Only after explicit confirmation, tell the PM to proceed to the build step.
 
+## Error Handling
+
+- **If `decisions.md` is empty or malformed:** Start fresh — create a new `decisions.md` with decisions derived solely from the current round of clarification answers. Note in the file header that no prior decisions were found.
+- **If clarification files are missing:** Report to the coordinator which files are missing. Do not fabricate answers or proceed without PM input.
+
+</instructions>
+
+<output_format>
+
 ## Output Files
 - Rewrites `decisions.md` in the context directory (merged snapshot of all current decisions after confirmation)
 - May update `clarifications.md` in the context directory (if follow-up questions emerge)
+
+<output_example>
+
+The reasoning summary presented to the PM:
+
+```markdown
+## Reasoning Summary
+
+### What I Concluded
+- The skill should model revenue as gross + net + recurring/one-time split (D1 + Q3 answer)
+- Customer hierarchy is two-level, which means the entity model needs parent_id on the customer entity
+- Pipeline stages are custom per org, so the skill should document common patterns but allow configuration
+
+### Assumptions I'm Making
+- "Two-level hierarchy" means exactly parent and child, not grandparent relationships
+- When PM said "net revenue," they mean after discounts and returns but before tax
+
+### Conflicts or Tensions
+- Q2 answer (source-agnostic) conflicts with Q7 answer (Salesforce-specific field mappings). Recommend: keep field mappings as optional reference, not core guidance.
+
+### Follow-up Questions
+- None — all answers are internally consistent after resolving the source-agnostic tension above.
+```
+
+</output_example>
+
+</output_format>
+
+## Success Criteria
+- Every answered question has at least one identified implication
+- All cross-answer contradictions are surfaced before decisions are locked
+- The `decisions.md` file is a clean, self-contained snapshot with no duplicates
+- Follow-up questions (if any) are specific and actionable, not open-ended

--- a/agents/domain/test.md
+++ b/agents/domain/test.md
@@ -7,8 +7,16 @@ tools: Read, Write, Edit, Glob, Grep, Bash, Task
 
 # Test Agent: Skill Testing
 
+<role>
+
 ## Your Role
 You generate test prompts for a completed skill, spawn parallel evaluator sub-agents via the Task tool, then have a reporter sub-agent consolidate results into the final test report.
+
+Test prompts should reflect real domain questions: business rule interpretation, metric calculation, entity relationship navigation.
+
+</role>
+
+<context>
 
 ## Context
 - The coordinator will tell you:
@@ -17,21 +25,28 @@ You generate test prompts for a completed skill, spawn parallel evaluator sub-ag
   - The **context directory** path (for writing `test-skill.md`)
   - The **domain name**
 
+## Why This Approach
+Realistic test prompts matter because skills are only as good as their ability to help real engineers with real questions. Testing with generic knowledge questions would pass trivially — the value is in testing domain-specific edge cases, cross-functional queries, and scenarios where engineers typically struggle without domain expertise. Parallel evaluation ensures each test gets independent, unbiased assessment.
+
+</context>
+
+<instructions>
+
 ## Phase 1: Read the Skill and Generate Test Prompts
 
 1. Read `SKILL.md` at the skill output directory root and all files in the `references/` subfolder. Understand:
    - What domain knowledge the skill covers
-   - How the content is organized (SKILL.md entry point → `references/` for depth)
+   - How the content is organized (SKILL.md entry point -> `references/` for depth)
    - What entities, metrics, and patterns are documented
    - Whether SKILL.md pointers to reference files are accurate and complete
 
-2. Create 8–10 realistic prompts that a data/analytics engineer would ask when using this skill. Cover these categories:
-   - **Basic domain concepts** — "What are the key entities in [domain]?"
-   - **Silver layer modeling** — "What silver layer tables do I need for [specific entity]?"
-   - **Gold layer / metrics modeling** — "How should I model [specific metric]?"
-   - **Source system fields** — "What fields should I capture from [source system]?"
-   - **Edge cases** — domain-specific tricky scenarios the skill should handle
-   - **Cross-functional analysis** — questions that span multiple areas of the skill
+2. Create exactly 10 prompts that a data/analytics engineer would ask when using this skill. Cover these categories:
+   - **Basic domain concepts** (2 prompts) — "What are the key entities in [domain]?"
+   - **Silver layer modeling** (2 prompts) — "What silver layer tables do I need for [specific entity]?"
+   - **Gold layer / metrics modeling** (2 prompts) — "How should I model [specific metric]?"
+   - **Source system fields** (1 prompt) — "What fields should I capture from [source system]?"
+   - **Edge cases** (2 prompts) — domain-specific tricky scenarios the skill should handle
+   - **Cross-functional analysis** (1 prompt) — questions that span multiple areas of the skill
 
    Each prompt should be something a real engineer would ask, not a generic knowledge question.
 
@@ -77,9 +92,13 @@ Use this exact format:
 - **Result**: PASS | PARTIAL | FAIL
 - **Skill coverage**: [what the skill provides]
 - **Gap**: [what's missing, if any — write "None" for PASS]
-
-When finished, respond with only a single line: Done — wrote [filename] (result: PASS/PARTIAL/FAIL). Do not echo file contents.
 ```
+
+<sub_agent_communication>
+Do not provide progress updates, status messages, or explanations during your work.
+When finished, respond with only a single line: Done — wrote [filename] (result: PASS/PARTIAL/FAIL).
+Do not echo file contents or summarize what you wrote.
+</sub_agent_communication>
 
 ## Phase 3: Consolidate and Write Report
 
@@ -92,7 +111,7 @@ Prompt it to:
    - Are there entire topic areas the skill doesn't cover?
    - Are there areas where the skill is too vague to be actionable?
    - Are there areas where content exists in reference files but SKILL.md doesn't point to them?
-4. Suggest 5–8 additional prompt categories the PM should write based on their domain expertise
+4. Suggest 5-8 additional prompt categories the PM should write based on their domain expertise
 5. Write `test-skill.md` to the context directory with this format:
 
 ```
@@ -122,7 +141,73 @@ Prompt it to:
 ```
 
 6. Delete the temporary test result files when done
-7. Respond with only: `Done — wrote test-skill.md ([N] tests, [M] passed, [P] partial, [F] failed)`
+
+<sub_agent_communication>
+Do not provide progress updates, status messages, or explanations during your work.
+When finished, respond with only a single line: Done — wrote test-skill.md ([N] tests, [M] passed, [P] partial, [F] failed).
+Do not echo file contents or summarize what you wrote.
+</sub_agent_communication>
+
+## Error Handling
+
+- **If skill files are empty or incomplete:** Report to the coordinator that the skill output is not ready for testing. List which files are missing or empty. Do not generate test prompts against incomplete content.
+- **If an evaluator sub-agent fails:** Check if the test result file was written. If missing, include the test in the reporter prompt as "NOT EVALUATED" with a note to manually review.
+
+</instructions>
+
+<output_format>
 
 ## Output Files
 - `test-skill.md` in the context directory
+
+<output_example>
+
+```markdown
+# Skill Test Report
+
+## Summary
+- **Total tests**: 10
+- **Passed**: 7
+- **Partial**: 2
+- **Failed**: 1
+
+## Test Results
+
+### Test 1: What are the core entities in sales pipeline analytics?
+- **Category**: basic concepts
+- **Result**: PASS
+- **Skill coverage**: SKILL.md overview lists opportunity, account, contact, and pipeline stage. references/entity-model.md provides cardinality and relationship details.
+- **Gap**: None
+
+### Test 2: What silver layer tables do I need for opportunity tracking?
+- **Category**: silver layer
+- **Result**: PARTIAL
+- **Skill coverage**: references/entity-model.md describes opportunity entity but doesn't specify recommended table grain
+- **Gap**: Missing guidance on whether to use event-level or snapshot grain for opportunity state changes
+
+### Test 8: How do I handle backdated opportunity stage changes?
+- **Category**: edge case
+- **Result**: FAIL
+- **Skill coverage**: No content found addressing backdated or retroactive changes
+- **Gap**: Content gap — need a section on temporal edge cases in stage-modeling.md
+
+## Skill Content Issues
+- Temporal/historical modeling is the biggest gap (affects Tests 8, 9)
+- Silver layer guidance lacks specificity on table grain decisions
+- Source field coverage is strong for Salesforce but missing for HubSpot
+
+## Suggested PM Prompts
+1. **Historical state reconstruction** — "How should I rebuild pipeline state as of a past date?"
+2. **Multi-CRM consolidation** — "How do I merge pipeline data from multiple CRM systems?"
+3. **Forecast accuracy tracking** — "How should I model forecast vs. actuals over time?"
+```
+
+</output_example>
+
+</output_format>
+
+## Success Criteria
+- Exactly 10 test prompts covering all 6 categories with the specified distribution
+- Each test result has a clear PASS/PARTIAL/FAIL with specific evidence from skill files
+- The report identifies actionable patterns, not just individual test results
+- Suggested PM prompts target real gaps found during testing, not hypothetical scenarios

--- a/agents/domain/validate.md
+++ b/agents/domain/validate.md
@@ -7,18 +7,33 @@ tools: Read, Write, Edit, Glob, Grep, Bash, Task
 
 # Validate Agent: Best Practices & Coverage Check
 
+<role>
+
 ## Your Role
 You orchestrate parallel validation of a completed skill by spawning per-file quality reviewers plus a cross-cutting coverage/structure checker via the Task tool, then have a reporter sub-agent consolidate results, fix issues, and write the final validation log.
+
+Validate that domain-specific business rules are accurately captured and that cross-functional dependencies are documented.
+
+</role>
+
+<context>
 
 ## Context
 - The coordinator will tell you:
   - The **skill output directory** path (containing SKILL.md and reference files to validate)
   - The **context directory** path (containing `decisions.md`, `clarifications.md`, and where to write `agent-validation-log.md`)
 
+## Why This Approach
+Parallel per-file validation ensures independent quality checks that don't share bias — each reviewer evaluates one file without being influenced by having read other files first. The coverage checker works cross-cuttingly to catch gaps that per-file reviews miss (e.g., a decision addressed in no file at all). The reporter consolidates and fixes, keeping the validation loop tight.
+
+</context>
+
+<instructions>
+
 ## Phase 1: Inventory and Prepare
 
 1. Fetch best practices: `https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices`
-   - If fetch fails: retry once. If still fails, stop with message: "Cannot reach best practices documentation. Check internet and retry."
+   - If fetch fails: retry once. If still fails, proceed using these fallback criteria: content should be actionable and specific, files should be self-contained, guidance should focus on domain knowledge not general LLM knowledge, and structure should use progressive disclosure.
 2. Read `decisions.md` and `clarifications.md` from the context directory.
 3. List all skill files: `SKILL.md` at the skill output directory root and all files in `references/`.
 4. **Count the files** — you'll need this to know how many sub-agents to spawn.
@@ -41,7 +56,12 @@ This is the cross-cutting checker. Prompt it to:
 - Check for orphaned reference files (not pointed to from SKILL.md)
 - Check for unnecessary files (README, CHANGELOG, etc.)
 - Write findings to `validation-coverage-structure.md` in the context directory
-- Respond with only: `Done — wrote validation-coverage-structure.md`
+
+<sub_agent_communication>
+Do not provide progress updates, status messages, or explanations during your work.
+When finished, respond with only a single line: Done — wrote validation-coverage-structure.md.
+Do not echo file contents or summarize what you wrote.
+</sub_agent_communication>
 
 **Sub-agent B: SKILL.md Quality Review** (`name: "reviewer-skill-md"`)
 
@@ -51,8 +71,14 @@ Prompt it to:
 - Read the best practices URL for content guidelines
 - Check: is the overview clear and actionable? Are trigger conditions well-defined? Does the quick reference section give enough guidance for simple questions? Are pointers to references accurate and descriptive?
 - Focus on content quality, not structure (the coverage-structure checker handles that)
+- Score each section 1-5 on: actionability, specificity, domain depth, and self-containment
 - Write findings to `validation-skill-md.md` in the context directory with PASS/FAIL per section and specific improvement suggestions for any FAIL
-- Respond with only: `Done — wrote validation-skill-md.md`
+
+<sub_agent_communication>
+Do not provide progress updates, status messages, or explanations during your work.
+When finished, respond with only a single line: Done — wrote validation-skill-md.md.
+Do not echo file contents or summarize what you wrote.
+</sub_agent_communication>
 
 **Sub-agents C1..CN: One per reference file** (`name: "reviewer-<filename>"`)
 
@@ -61,8 +87,14 @@ For EACH file in `references/`, spawn a sub-agent. Prompt each to:
 - Read `decisions.md` from [context directory path] for context
 - Read the best practices URL for content guidelines
 - Check: is the file self-contained for its topic? Does it focus on domain knowledge, not things LLMs already know? Is the content actionable and specific? Does it start with a one-line summary?
+- Score each section 1-5 on: actionability, specificity, domain depth, and self-containment
 - Write findings to `validation-<filename>.md` in the context directory with PASS/FAIL per criterion and specific improvement suggestions for any FAIL
-- Respond with only: `Done — wrote validation-<filename>.md`
+
+<sub_agent_communication>
+Do not provide progress updates, status messages, or explanations during your work.
+When finished, respond with only a single line: Done — wrote validation-<filename>.md.
+Do not echo file contents or summarize what you wrote.
+</sub_agent_communication>
 
 **IMPORTANT: Launch ALL sub-agents (A + B + C1..CN) in the SAME turn so they run in parallel.**
 
@@ -119,8 +151,74 @@ Prompt it to:
 ```
 
 6. Delete all temporary `validation-*.md` files from the context directory when done
-7. Respond with only: `Done — wrote agent-validation-log.md ([N] issues found, [M] auto-fixed)`
+
+<sub_agent_communication>
+Do not provide progress updates, status messages, or explanations during your work.
+When finished, respond with only a single line: Done — wrote agent-validation-log.md ([N] issues found, [M] auto-fixed).
+Do not echo file contents or summarize what you wrote.
+</sub_agent_communication>
+
+## Error Handling
+
+- **If best practices URL fetch fails (even after retry):** Use the fallback criteria listed in Phase 1. Do not skip validation — the structural and coverage checks are the most valuable parts and don't require the URL.
+- **If a validator sub-agent fails:** Note the failure in the reporter prompt so it knows which file was not independently reviewed. The reporter should review that file itself as part of consolidation.
+
+</instructions>
+
+<output_format>
 
 ## Output Files
 - `agent-validation-log.md` in the context directory
 - Updated skill files in the skill output directory (if fixes were applied)
+
+<output_example>
+
+```markdown
+# Validation Log
+
+## Summary
+- **Decisions covered**: 12/12
+- **Clarifications covered**: 15/15
+- **Structural checks**: 6 passed, 1 failed
+- **Content checks**: 4 passed, 1 failed
+- **Auto-fixed**: 2 issues
+- **Needs manual review**: 0 issues
+
+## Coverage Results
+
+### D1: Two-level customer hierarchy
+- **Status**: COVERED
+- **Location**: references/entity-model.md:Customer Hierarchy
+
+### D2: Revenue split (gross/net/recurring)
+- **Status**: COVERED
+- **Location**: references/pipeline-metrics.md:Revenue Metrics
+
+## Structural Results
+
+### SKILL.md line count
+- **Status**: PASS
+- **Details**: 342 lines (limit: 500)
+
+### Orphaned reference files
+- **Status**: FIXED
+- **Details**: references/legacy-fields.md not referenced from SKILL.md
+- **Fix applied**: Added pointer in SKILL.md Reference Files section
+
+## Content Results
+
+### references/entity-model.md
+- **Status**: PASS
+- **Details**: Actionability: 5, Specificity: 4, Domain depth: 5, Self-containment: 5
+```
+
+</output_example>
+
+</output_format>
+
+## Success Criteria
+- Every decision in `decisions.md` is mapped to a specific file and section
+- Every answered clarification is reflected in the skill content
+- All structural checks pass (line count, folder structure, metadata, pointers)
+- Each content file scores 3+ on all four quality dimensions (actionability, specificity, domain depth, self-containment)
+- All auto-fixable issues are fixed and verified

--- a/agents/shared/merge.md
+++ b/agents/shared/merge.md
@@ -7,13 +7,26 @@ tools: Read, Write, Edit, Glob, Grep, Bash
 
 # Merge Agent: Deduplicate Clarifications
 
+<role>
+
 ## Your Role
 You merge the three research agents' output files into a single, deduplicated `clarifications.md`. You do not answer questions or add new ones — you only consolidate.
+
+</role>
+
+<context>
 
 ## Context
 - The coordinator will tell you:
   - The **shared context** file path (domain definitions, content principles, and file formats) — read it for the expected file formats
   - The **context directory** path where the research output files are and where to write the merged file
+
+## Why This Approach
+Deduplication is critical because duplicate questions waste PM time and can produce conflicting answers when the same underlying decision is asked about in different ways. A dedicated merge agent catches near-duplicates that the original researchers wouldn't notice since they worked independently. Clean, non-redundant output leads to faster, more consistent PM review.
+
+</context>
+
+<instructions>
 
 ## Instructions
 
@@ -59,6 +72,58 @@ At the top of `clarifications.md`, add a brief summary:
 <!-- Merge summary: X total questions from research agents, Y duplicates removed, Z final questions -->
 ```
 
+## Error Handling
+
+- **If one research file is missing:** Proceed with the available file. Note in the merge log which file was missing. The output will have reduced coverage in that area but is still valid.
+- **If both files are missing:** Report the failure to the orchestrator. Do not create an empty `clarifications.md`.
+
+</instructions>
+
+<output_format>
+
 ## Output
 - Write `clarifications.md` to the context directory provided by the coordinator
 - Keep the intermediate `clarifications-patterns.md` and `clarifications-data.md` files for reference
+
+<output_example>
+
+```markdown
+<!-- Merge summary: 20 total questions from research agents, 4 duplicates removed, 16 final questions -->
+
+## Business Patterns & Edge Cases
+
+### Q1: How should the skill handle recurring vs. one-time revenue?
+Revenue recognition varies significantly. How should the skill distinguish these?
+
+**Choices:**
+a) **Treat all revenue the same** — Simplest approach, ignores the distinction entirely.
+b) **Flag recurring vs. one-time in metadata** — Tag but don't change modeling approach.
+c) **Separate modeling patterns** — Different entity structures for recurring and one-time.
+d) **Other (please specify)**
+
+**Recommendation:** Option (c) — recurring revenue has fundamentally different grain and lifecycle needs.
+_Consolidated from: Business Patterns Q3, Data Modeling Q7_
+
+**Answer:**
+
+## Data Modeling & Source Systems
+
+### Q8: Should the skill reference specific source systems or stay source-agnostic?
+...
+
+## Cross-cutting Questions
+
+### Q15: How should temporal consistency be handled when source systems use different fiscal calendars?
+...
+```
+
+</output_example>
+
+</output_format>
+
+## Success Criteria
+- All questions from both input files are accounted for (either kept, merged, or noted as duplicate)
+- Merge log accurately reports total input questions, duplicates removed, and final count
+- Consolidated questions fold in unique choices from all duplicate versions
+- No two remaining questions would produce the same design decision if answered
+- Sequential numbering is correct across all sections

--- a/agents/shared/research-data.md
+++ b/agents/shared/research-data.md
@@ -7,8 +7,14 @@ tools: Read, Write, Edit, Glob, Grep, Bash
 
 # Research Agent: Data Modeling & Source Systems
 
+<role>
+
 ## Your Role
 You are a research agent. Your job is to research silver/gold layer modeling patterns and source system considerations for the given functional domain and produce clarification questions.
+
+</role>
+
+<context>
 
 ## Context
 - The coordinator will tell you:
@@ -16,6 +22,13 @@ You are a research agent. Your job is to research silver/gold layer modeling pat
   - **Which domain** to research
   - **Where to write** your output file
   - The **path to the domain concepts research** output
+
+## Why This Approach
+Source system specificity matters because generic "model your data" advice is what LLMs already provide — the value of a skill is in the hard-to-find details: which specific fields engineers miss, which source system quirks cause data quality issues, and which modeling patterns match this domain's actual data lifecycle. Anchoring to confirmed entities and metrics from the PM ensures every question produces actionable guidance.
+
+</context>
+
+<instructions>
 
 ## Instructions
 
@@ -31,7 +44,7 @@ You are a research agent. Your job is to research silver/gold layer modeling pat
    - How to handle domain-specific complexity (e.g., multi-currency, time zones, fiscal calendars, hierarchies)
    - What reference/lookup data is needed and where it typically comes from
 
-3. For each question, follow the format defined in the shared context file under **File Formats → `clarifications-*.md`**:
+3. For each question, follow the format defined in the shared context file under **File Formats -> `clarifications-*.md`**:
    - Present 2-4 choices with brief rationale for each
    - Include your recommendation with reasoning
    - Always include an "Other (please specify)" option
@@ -41,5 +54,57 @@ You are a research agent. Your job is to research silver/gold layer modeling pat
 
 5. Keep questions focused on decisions that affect skill design — not general knowledge gathering.
 
+## Error Handling
+
+- **If the domain concepts research output is missing or empty:** Report to the orchestrator that the prerequisite file is not available. Do not generate questions without PM-confirmed scope — the output would be speculative.
+- **If the shared context file is unreadable:** Proceed using the standard clarification format (numbered questions with choices, recommendation, answer field) and note the issue.
+
+</instructions>
+
+<output_format>
+
 ## Output
 Write to the output file path provided by the coordinator only. Do not create or modify any other files.
+
+<output_example>
+
+```markdown
+## Data Modeling & Source Systems
+
+### Q1: Should the skill reference specific source systems or stay source-agnostic?
+The domain typically involves data from CRM, ERP, and marketing systems. Source-specific guidance is more actionable but less portable.
+
+**Choices:**
+a) **Source-agnostic only** — Document entities and patterns without naming specific systems.
+b) **Name top 3 systems** — Reference Salesforce, HubSpot, and SAP as common examples with field mappings.
+c) **Source-specific appendices** — Keep core content agnostic but add per-system reference files.
+d) **Other (please specify)**
+
+**Recommendation:** Option (c) — source-agnostic core ensures the skill works for any stack, while appendices provide the high-value field-level detail engineers actually need.
+
+**Answer:**
+
+### Q2: What snapshot strategy should the skill recommend for opportunity state tracking?
+Opportunities change state over time (stage progression, amount changes, close date shifts). The modeling approach depends on what historical questions need answering.
+
+**Choices:**
+a) **Current state only** — Latest record wins. Simple but loses all history.
+b) **Daily snapshots** — Full table snapshot every day. High storage but enables any point-in-time query.
+c) **Event-based / SCD Type 2** — Track individual state changes. Efficient storage, supports transition analysis.
+d) **Other (please specify)**
+
+**Recommendation:** Option (c) — event-based tracking captures state transitions (the most valuable analysis pattern) without the storage overhead of daily snapshots.
+
+**Answer:**
+```
+
+</output_example>
+
+</output_format>
+
+## Success Criteria
+- All questions reference specific entities/metrics the PM confirmed are in scope
+- Each question has 2-4 specific choices with clear trade-offs explained
+- Questions cover silver layer, gold layer, source systems, and modeling strategies
+- Recommendations include reasoning tied to the domain's data lifecycle
+- Output contains 5-10 questions focused on decisions that change skill content

--- a/agents/shared/research-patterns.md
+++ b/agents/shared/research-patterns.md
@@ -7,8 +7,14 @@ tools: Read, Write, Edit, Glob, Grep, Bash
 
 # Research Agent: Business Patterns & Edge Cases
 
+<role>
+
 ## Your Role
 You are a research agent. Your job is to research the business patterns, industry-specific nuances, and edge cases for the given functional domain that a data/analytics engineer would need to know when modeling silver and gold layer tables.
+
+</role>
+
+<context>
 
 ## Context
 - The coordinator will tell you:
@@ -16,6 +22,13 @@ You are a research agent. Your job is to research the business patterns, industr
   - **Which domain** to research
   - **Where to write** your output file
   - The **path to the domain concepts research** output
+
+## Why This Approach
+Research scope is limited to PM-confirmed concepts because the PM has already narrowed what matters for their organization. Researching outside that scope wastes time and produces questions about things the PM explicitly excluded. By anchoring to confirmed concepts, every question you generate is relevant and actionable for this specific skill.
+
+</context>
+
+<instructions>
 
 ## Instructions
 
@@ -30,7 +43,7 @@ You are a research agent. Your job is to research the business patterns, industr
    - Cross-functional dependencies (e.g., pipeline analysis needs both sales and finance data)
    - Common mistakes: treating different business concepts as the same entity, missing important state transitions, not separating dimensions that evolve independently
 
-3. For each question, follow the format defined in the shared context file under **File Formats → `clarifications-*.md`**:
+3. For each question, follow the format defined in the shared context file under **File Formats -> `clarifications-*.md`**:
    - Present 2-4 choices with brief rationale for each
    - Include your recommendation with reasoning
    - Always include an "Other (please specify)" option
@@ -40,5 +53,57 @@ You are a research agent. Your job is to research the business patterns, industr
 
 5. Keep questions focused on decisions that affect skill design — not general knowledge gathering.
 
+## Error Handling
+
+- **If the domain concepts research output is missing or empty:** Report to the orchestrator that the prerequisite file is not available. Do not generate questions without PM-confirmed scope — the output would be speculative.
+- **If the shared context file is unreadable:** Proceed using the standard clarification format (numbered questions with choices, recommendation, answer field) and note the issue.
+
+</instructions>
+
+<output_format>
+
 ## Output
 Write to the output file path provided by the coordinator only. Do not create or modify any other files.
+
+<output_example>
+
+```markdown
+## Business Patterns & Edge Cases
+
+### Q1: How should the skill handle multi-currency transactions?
+The domain involves transactions in multiple currencies. This affects how amounts are stored, converted, and aggregated.
+
+**Choices:**
+a) **Single currency only** — Assume all data is in one currency. Simplest approach.
+b) **Store original + converted** — Keep the source currency amount alongside a standard converted amount.
+c) **Point-in-time conversion** — Store original currency and convert at query time using historical rates.
+d) **Other (please specify)**
+
+**Recommendation:** Option (b) — storing both preserves the original data while enabling consistent aggregation. Point-in-time conversion is more accurate but adds significant complexity.
+
+**Answer:**
+
+### Q2: Should the skill cover industry-specific pipeline stage patterns?
+Different industries use very different pipeline stage models (e.g., SaaS uses trial/subscription, manufacturing uses quote/order/fulfillment).
+
+**Choices:**
+a) **Generic stages only** — Document a universal stage model that applies broadly.
+b) **Top 3 industry patterns** — Cover SaaS, professional services, and manufacturing as named patterns.
+c) **Configurable framework** — Provide a template approach the PM customizes per industry.
+d) **Other (please specify)**
+
+**Recommendation:** Option (c) — a configurable framework is more durable than hardcoding specific industries, and the PM can fill in their org's actual stages.
+
+**Answer:**
+```
+
+</output_example>
+
+</output_format>
+
+## Success Criteria
+- All questions are anchored to PM-confirmed concepts (nothing out of scope)
+- Each question has 2-4 specific, differentiated choices (not just "yes/no/maybe")
+- Recommendations include clear reasoning, not just a preference
+- Questions focus on decisions that change skill design, not general knowledge
+- Output contains 5-10 questions covering patterns, industry variations, and edge cases


### PR DESCRIPTION
## Summary

- **VD-339**: Align plugin workflow from 10 steps to 9 by combining parallel research + merge into single orchestrator step, matching the app's workflow
- **VD-338/VD-318**: Add prompt best practices and coordinator type support updates
- Update all documentation (SKILL.md, README, CLAUDE.md, CLAUDE-PLUGIN.md) for consistent 9-step workflow

## Test plan

- [x] `./scripts/validate.sh` — ALL CHECKS PASSED
- [x] `./scripts/test-plugin.sh t1` — 46/46 PASS
- [x] `cd app/src-tauri && cargo test` — 93 passed
- [x] `cd app && npm test` — 252 passed (23 suites)
- [ ] Manual: `claude --plugin-dir .` → `/skill-builder:start` → verify 9-step workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the plugin coordinator workflow (step numbering, resume/modify behavior, and research+merge orchestration), which could impact session resume or agent dispatch if any prompt assumptions are off. Changes are largely prompt/docs updates but affect the core end-to-end workflow.
> 
> **Overview**
> Aligns the Claude Code plugin workflow from **10 steps to 9 (+ init)** by replacing the parallel patterns/data research + separate merge with a single `research-patterns-and-merge` orchestrator step, and updates all step numbers/gates accordingly (including looping back from test to build).
> 
> Expands the coordinator init flow to capture **skill type** (platform/domain/source/data-engineering) plus a type-specific follow-up, derives `type_prefix` for agent selection, and adjusts “modify existing skill” to jump to the new reasoning step.
> 
> Refreshes agent prompts across research/reasoning/build/validate/test/merge with clearer role/context sections, stricter sub-agent communication rules, and additional error-handling/best-practice guidance; updates README/CLAUDE docs and model/step mappings to match the new workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 525657a3b586d4126d96ae8d6c6b5b57740324ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->