### PR TITLE
VD-387: Move packaging to dashboard right-click action

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -40,6 +40,7 @@ pub fn run() {
             commands::clarification::save_raw_file,
             commands::files::list_skill_files,
             commands::files::read_file,
+            commands::files::copy_file,
             commands::workflow::run_workflow_step,
             commands::workflow::run_review_step,
             commands::workflow::package_skill,

--- a/app/src/__tests__/components/skill-card.test.tsx
+++ b/app/src/__tests__/components/skill-card.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import SkillCard from "@/components/skill-card";
+import SkillCard, { hasBuildOutput } from "@/components/skill-card";
 import type { SkillSummary } from "@/lib/types";
 
 const baseSkill: SkillSummary = {
@@ -88,8 +88,8 @@ describe("SkillCard", () => {
     render(
       <SkillCard skill={baseSkill} onContinue={vi.fn()} onDelete={vi.fn()} />
     );
-    // Step 3 => Math.round((4/9)*100) = 44%
-    expect(screen.getByText("44%")).toBeInTheDocument();
+    // Step 3 => Math.round((4/8)*100) = 50%
+    expect(screen.getByText("50%")).toBeInTheDocument();
   });
 
   it("shows 100% for completed step", () => {
@@ -179,5 +179,52 @@ describe("SkillCard", () => {
     expect(screen.queryByText("Domain")).not.toBeInTheDocument();
     expect(screen.queryByText("Source")).not.toBeInTheDocument();
     expect(screen.queryByText("Data Engineering")).not.toBeInTheDocument();
+  });
+});
+
+describe("hasBuildOutput", () => {
+  it("returns false for null current_step", () => {
+    const skill = { ...baseSkill, current_step: null, status: "in_progress" };
+    expect(hasBuildOutput(skill)).toBe(false);
+  });
+
+  it("returns false for step less than 6", () => {
+    const skill = { ...baseSkill, current_step: "Step 3", status: "in_progress" };
+    expect(hasBuildOutput(skill)).toBe(false);
+  });
+
+  it("returns false for step 5 (Build step itself is in progress)", () => {
+    const skill = { ...baseSkill, current_step: "Step 5", status: "in_progress" };
+    expect(hasBuildOutput(skill)).toBe(false);
+  });
+
+  it("returns true for step 6 (past Build)", () => {
+    const skill = { ...baseSkill, current_step: "Step 6", status: "in_progress" };
+    expect(hasBuildOutput(skill)).toBe(true);
+  });
+
+  it("returns true for step 7", () => {
+    const skill = { ...baseSkill, current_step: "Step 7", status: "in_progress" };
+    expect(hasBuildOutput(skill)).toBe(true);
+  });
+
+  it("returns true when status is completed", () => {
+    const skill = { ...baseSkill, current_step: "Step 3", status: "completed" };
+    expect(hasBuildOutput(skill)).toBe(true);
+  });
+
+  it("returns true when current_step text says completed", () => {
+    const skill = { ...baseSkill, current_step: "completed", status: "in_progress" };
+    expect(hasBuildOutput(skill)).toBe(true);
+  });
+
+  it("returns false for initialization step", () => {
+    const skill = { ...baseSkill, current_step: "initialization", status: "in_progress" };
+    expect(hasBuildOutput(skill)).toBe(false);
+  });
+
+  it("returns true for completed status even with null step", () => {
+    const skill = { ...baseSkill, current_step: null, status: "completed" };
+    expect(hasBuildOutput(skill)).toBe(true);
   });
 });

--- a/app/src/__tests__/stores/workflow-store.test.ts
+++ b/app/src/__tests__/stores/workflow-store.test.ts
@@ -6,18 +6,18 @@ describe("useWorkflowStore", () => {
     useWorkflowStore.getState().reset();
   });
 
-  it("has correct initial state with 9 steps, all pending, currentStep=0", () => {
+  it("has correct initial state with 8 steps, all pending, currentStep=0", () => {
     const state = useWorkflowStore.getState();
     expect(state.skillName).toBeNull();
     expect(state.domain).toBeNull();
     expect(state.currentStep).toBe(0);
     expect(state.isRunning).toBe(false);
-    expect(state.steps).toHaveLength(9);
+    expect(state.steps).toHaveLength(8);
     state.steps.forEach((step) => {
       expect(step.status).toBe("pending");
     });
-    // Verify step IDs are 0-8
-    expect(state.steps.map((s) => s.id)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+    // Verify step IDs are 0-7
+    expect(state.steps.map((s) => s.id)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
   });
 
   it("initWorkflow sets skillName, domain, and resets steps", () => {
@@ -87,7 +87,7 @@ describe("useWorkflowStore", () => {
     expect(state.domain).toBeNull();
     expect(state.currentStep).toBe(0);
     expect(state.isRunning).toBe(false);
-    expect(state.steps).toHaveLength(9);
+    expect(state.steps).toHaveLength(8);
     state.steps.forEach((step) => {
       expect(step.status).toBe("pending");
     });
@@ -110,8 +110,8 @@ describe("useWorkflowStore", () => {
     expect(state.steps[0].status).toBe("completed");
     expect(state.steps[1].status).toBe("completed");
     expect(state.steps[2].status).toBe("completed");
-    // Steps 3-8 should be reset to pending
-    for (let i = 3; i <= 8; i++) {
+    // Steps 3-7 should be reset to pending
+    for (let i = 3; i <= 7; i++) {
       expect(state.steps[i].status).toBe("pending");
     }
     // currentStep should be 3
@@ -122,10 +122,10 @@ describe("useWorkflowStore", () => {
 
   it("rerunFromStep from step 0 resets all steps", () => {
     const store = useWorkflowStore.getState();
-    for (let i = 0; i <= 8; i++) {
+    for (let i = 0; i <= 7; i++) {
       store.updateStepStatus(i, "completed");
     }
-    store.setCurrentStep(8);
+    store.setCurrentStep(7);
 
     useWorkflowStore.getState().rerunFromStep(0);
 
@@ -143,6 +143,55 @@ describe("useWorkflowStore", () => {
     expect(state.steps[3].name).toBe("Human Review");
     expect(state.steps[4].name).toBe("Reasoning");
     expect(state.steps[5].name).toBe("Build Skill");
-    expect(state.steps[8].name).toBe("Package");
+    expect(state.steps[7].name).toBe("Test");
+  });
+
+  it("does not have a Package step", () => {
+    const state = useWorkflowStore.getState();
+    expect(state.steps.find((s) => s.name === "Package")).toBeUndefined();
+  });
+
+  describe("loadWorkflowState migration safety", () => {
+    it("ignores step_id 8 from legacy SQLite data (removed Package step)", () => {
+      // Simulate SQLite returning completed steps including the old Package step (8)
+      useWorkflowStore.getState().loadWorkflowState([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+
+      const state = useWorkflowStore.getState();
+      // All 8 real steps (0-7) should be completed
+      state.steps.forEach((step) => {
+        expect(step.status).toBe("completed");
+      });
+      // No step with id 8 should exist
+      expect(state.steps.find((s) => s.id === 8)).toBeUndefined();
+      expect(state.steps).toHaveLength(8);
+      // currentStep should be the last valid step since all are completed
+      expect(state.currentStep).toBe(7);
+      expect(state.hydrated).toBe(true);
+    });
+
+    it("ignores step_id 9 from legacy SQLite data", () => {
+      useWorkflowStore.getState().loadWorkflowState([0, 1, 2, 3, 4, 5, 6, 7, 9]);
+
+      const state = useWorkflowStore.getState();
+      state.steps.forEach((step) => {
+        expect(step.status).toBe("completed");
+      });
+      expect(state.steps.find((s) => s.id === 9)).toBeUndefined();
+    });
+
+    it("correctly hydrates partial progress with legacy step_id 8 present", () => {
+      // Steps 0-4 completed in SQLite, plus leftover step 8 from old data
+      useWorkflowStore.getState().loadWorkflowState([0, 1, 2, 3, 4, 8]);
+
+      const state = useWorkflowStore.getState();
+      for (let i = 0; i <= 4; i++) {
+        expect(state.steps[i].status).toBe("completed");
+      }
+      for (let i = 5; i <= 7; i++) {
+        expect(state.steps[i].status).toBe("pending");
+      }
+      // First incomplete step is 5
+      expect(state.currentStep).toBe(5);
+    });
   });
 });

--- a/app/src/components/ui/context-menu.tsx
+++ b/app/src/components/ui/context-menu.tsx
@@ -1,0 +1,255 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { ContextMenu as ContextMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function ContextMenu({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
+}
+
+function ContextMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return (
+    <ContextMenuPrimitive.Trigger
+      data-slot="context-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function ContextMenuPortal({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
+  return (
+    <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
+  )
+}
+
+function ContextMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  )
+}
+
+function ContextMenuGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
+  return (
+    <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
+  )
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.CheckboxItem>) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  )
+}
+
+function ContextMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
+  return (
+    <ContextMenuPrimitive.RadioGroup
+      data-slot="context-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function ContextMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioItem>) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  )
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.Label
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuSub({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </ContextMenuPrimitive.SubTrigger>
+  )
+}
+
+function ContextMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
+  return (
+    <ContextMenuPrimitive.SubContent
+      data-slot="context-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuPortal,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuLabel,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
+}

--- a/app/src/components/workflow-step-complete.tsx
+++ b/app/src/components/workflow-step-complete.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, FileText, Clock, DollarSign, RotateCcw, ArrowRight, MessageSquare } from "lucide-react";
+import { CheckCircle2, FileText, Clock, DollarSign, RotateCcw, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface WorkflowStepCompleteProps {
@@ -9,7 +9,6 @@ interface WorkflowStepCompleteProps {
   onRerun?: () => void;
   onNextStep?: () => void;
   isLastStep?: boolean;
-  onRefineChat?: () => void;
 }
 
 function formatDuration(ms: number): string {
@@ -28,7 +27,6 @@ export function WorkflowStepComplete({
   onRerun,
   onNextStep,
   isLastStep = false,
-  onRefineChat,
 }: WorkflowStepCompleteProps) {
   return (
     <div className="flex flex-1 items-center justify-center">
@@ -79,12 +77,6 @@ export function WorkflowStepComplete({
             <Button size="sm" onClick={onNextStep}>
               <ArrowRight className="size-3.5" />
               Next Step
-            </Button>
-          )}
-          {isLastStep && onRefineChat && (
-            <Button variant="outline" size="sm" onClick={onRefineChat}>
-              <MessageSquare className="size-3.5" />
-              Refine with Chat
             </Button>
           )}
         </div>

--- a/app/src/stores/workflow-store.ts
+++ b/app/src/stores/workflow-store.ts
@@ -76,12 +76,6 @@ const defaultSteps: WorkflowStep[] = [
     description: "Generate and evaluate test prompts",
     status: "pending",
   },
-  {
-    id: 8,
-    name: "Package",
-    description: "Package skill into a deployable .skill file",
-    status: "pending",
-  },
 ];
 
 export const useWorkflowStore = create<WorkflowState>((set) => ({
@@ -128,8 +122,13 @@ export const useWorkflowStore = create<WorkflowState>((set) => ({
 
   loadWorkflowState: (completedStepIds) =>
     set((state) => {
+      // Filter out step IDs that no longer exist in the workflow (e.g. the
+      // removed Package step 8, or any higher IDs from legacy data).
+      const validStepIds = new Set(state.steps.map((s) => s.id));
+      const filtered = completedStepIds.filter((id) => validStepIds.has(id));
+
       const steps = state.steps.map((s) =>
-        completedStepIds.includes(s.id) ? { ...s, status: "completed" as const } : s
+        filtered.includes(s.id) ? { ...s, status: "completed" as const } : s
       );
       const firstIncomplete = steps.find((s) => s.status !== "completed");
       return {

--- a/app/src/test/mocks/tauri.ts
+++ b/app/src/test/mocks/tauri.ts
@@ -12,8 +12,10 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: mockListen,
 }));
 
+export const mockDialogSave = vi.fn();
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
+  save: mockDialogSave,
 }));
 
 // Mock @tauri-apps/api/window
@@ -51,4 +53,5 @@ export function resetTauriMocks(): void {
   mockInvoke.mockReset();
   mockListen.mockReset().mockReturnValue(Promise.resolve(() => {}));
   mockGetCurrentWindow.mockClear();
+  mockDialogSave.mockReset();
 }


### PR DESCRIPTION
## Summary
- Remove Package step from workflow (store, STEP_CONFIGS, Rust backend) — steps reduced from 9 to 8
- Add right-click context menu on dashboard skill cards with "Download .skill" option
- Download flow: `packageSkill` → native save dialog → `copy_file` to user-chosen path
- Migration safety: filter legacy step IDs, clamp progress to 100% for old data
- Clean up dead code: `onRefineChat` prop, stale rerun warning dialog

## Test plan
- [x] 343 frontend tests passing (20 files)
- [x] 96 backend tests passing
- [x] New tests: hasBuildOutput (9), migration safety (3), copy_file (3)
- [ ] Manual: right-click skill card on dashboard, verify "Download .skill" appears
- [ ] Manual: verify download is disabled for skills that haven't completed Build step
- [ ] Manual: verify native save dialog works and file is copied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)