### PR TITLE
VD-388: Make Refine Skill the final workflow step

### DIFF
--- a/app/src/__tests__/components/skill-card.test.tsx
+++ b/app/src/__tests__/components/skill-card.test.tsx
@@ -88,8 +88,8 @@ describe("SkillCard", () => {
     render(
       <SkillCard skill={baseSkill} onContinue={vi.fn()} onDelete={vi.fn()} />
     );
-    // Step 3 => Math.round((4/8)*100) = 50%
-    expect(screen.getByText("50%")).toBeInTheDocument();
+    // Step 3 => Math.round((4/9)*100) = 44%
+    expect(screen.getByText("44%")).toBeInTheDocument();
   });
 
   it("shows 100% for completed step", () => {

--- a/app/src/__tests__/stores/workflow-store.test.ts
+++ b/app/src/__tests__/stores/workflow-store.test.ts
@@ -6,18 +6,18 @@ describe("useWorkflowStore", () => {
     useWorkflowStore.getState().reset();
   });
 
-  it("has correct initial state with 8 steps, all pending, currentStep=0", () => {
+  it("has correct initial state with 9 steps, all pending, currentStep=0", () => {
     const state = useWorkflowStore.getState();
     expect(state.skillName).toBeNull();
     expect(state.domain).toBeNull();
     expect(state.currentStep).toBe(0);
     expect(state.isRunning).toBe(false);
-    expect(state.steps).toHaveLength(8);
+    expect(state.steps).toHaveLength(9);
     state.steps.forEach((step) => {
       expect(step.status).toBe("pending");
     });
-    // Verify step IDs are 0-7
-    expect(state.steps.map((s) => s.id)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    // Verify step IDs are 0-8
+    expect(state.steps.map((s) => s.id)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
   it("initWorkflow sets skillName, domain, and resets steps", () => {
@@ -87,7 +87,7 @@ describe("useWorkflowStore", () => {
     expect(state.domain).toBeNull();
     expect(state.currentStep).toBe(0);
     expect(state.isRunning).toBe(false);
-    expect(state.steps).toHaveLength(8);
+    expect(state.steps).toHaveLength(9);
     state.steps.forEach((step) => {
       expect(step.status).toBe("pending");
     });
@@ -110,8 +110,8 @@ describe("useWorkflowStore", () => {
     expect(state.steps[0].status).toBe("completed");
     expect(state.steps[1].status).toBe("completed");
     expect(state.steps[2].status).toBe("completed");
-    // Steps 3-7 should be reset to pending
-    for (let i = 3; i <= 7; i++) {
+    // Steps 3-8 should be reset to pending
+    for (let i = 3; i <= 8; i++) {
       expect(state.steps[i].status).toBe("pending");
     }
     // currentStep should be 3
@@ -122,10 +122,10 @@ describe("useWorkflowStore", () => {
 
   it("rerunFromStep from step 0 resets all steps", () => {
     const store = useWorkflowStore.getState();
-    for (let i = 0; i <= 7; i++) {
+    for (let i = 0; i <= 8; i++) {
       store.updateStepStatus(i, "completed");
     }
-    store.setCurrentStep(7);
+    store.setCurrentStep(8);
 
     useWorkflowStore.getState().rerunFromStep(0);
 
@@ -144,6 +144,7 @@ describe("useWorkflowStore", () => {
     expect(state.steps[4].name).toBe("Reasoning");
     expect(state.steps[5].name).toBe("Build Skill");
     expect(state.steps[7].name).toBe("Test");
+    expect(state.steps[8].name).toBe("Refine Skill");
   });
 
   it("does not have a Package step", () => {
@@ -152,42 +153,41 @@ describe("useWorkflowStore", () => {
   });
 
   describe("loadWorkflowState migration safety", () => {
-    it("ignores step_id 8 from legacy SQLite data (removed Package step)", () => {
-      // Simulate SQLite returning completed steps including the old Package step (8)
+    it("completes all 9 steps including step 8 (Refine Skill)", () => {
+      // Simulate SQLite returning all steps completed including the new Refine Skill step (8)
       useWorkflowStore.getState().loadWorkflowState([0, 1, 2, 3, 4, 5, 6, 7, 8]);
 
       const state = useWorkflowStore.getState();
-      // All 8 real steps (0-7) should be completed
+      // All 9 real steps (0-8) should be completed
       state.steps.forEach((step) => {
         expect(step.status).toBe("completed");
       });
-      // No step with id 8 should exist
-      expect(state.steps.find((s) => s.id === 8)).toBeUndefined();
-      expect(state.steps).toHaveLength(8);
+      expect(state.steps).toHaveLength(9);
       // currentStep should be the last valid step since all are completed
-      expect(state.currentStep).toBe(7);
+      expect(state.currentStep).toBe(8);
       expect(state.hydrated).toBe(true);
     });
 
     it("ignores step_id 9 from legacy SQLite data", () => {
-      useWorkflowStore.getState().loadWorkflowState([0, 1, 2, 3, 4, 5, 6, 7, 9]);
+      useWorkflowStore.getState().loadWorkflowState([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
       const state = useWorkflowStore.getState();
       state.steps.forEach((step) => {
         expect(step.status).toBe("completed");
       });
       expect(state.steps.find((s) => s.id === 9)).toBeUndefined();
+      expect(state.steps).toHaveLength(9);
     });
 
-    it("correctly hydrates partial progress with legacy step_id 8 present", () => {
-      // Steps 0-4 completed in SQLite, plus leftover step 8 from old data
-      useWorkflowStore.getState().loadWorkflowState([0, 1, 2, 3, 4, 8]);
+    it("correctly hydrates partial progress with legacy step_id 9 present", () => {
+      // Steps 0-4 completed in SQLite, plus leftover step 9 from old data
+      useWorkflowStore.getState().loadWorkflowState([0, 1, 2, 3, 4, 9]);
 
       const state = useWorkflowStore.getState();
       for (let i = 0; i <= 4; i++) {
         expect(state.steps[i].status).toBe("completed");
       }
-      for (let i = 5; i <= 7; i++) {
+      for (let i = 5; i <= 8; i++) {
         expect(state.steps[i].status).toBe("pending");
       }
       // First incomplete step is 5

--- a/app/src/components/refinement-chat.tsx
+++ b/app/src/components/refinement-chat.tsx
@@ -5,7 +5,6 @@ import {
   Send,
   User,
   Bot,
-  X,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -29,7 +28,6 @@ export interface RefinementChatProps {
   skillName: string;
   domain: string;
   workspacePath: string;
-  onDismiss: () => void;
 }
 
 interface ChatMessage {
@@ -54,7 +52,6 @@ export function RefinementChat({
   skillName,
   domain,
   workspacePath,
-  onDismiss,
 }: RefinementChatProps) {
   // Core state
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -88,7 +85,7 @@ export function RefinementChat({
       };
       saveArtifactContent(
         skillName,
-        9, // Refinement chat step
+        8, // Refinement chat step
         SESSION_ARTIFACT,
         JSON.stringify(state, null, 2),
       ).catch(() => {});
@@ -278,14 +275,6 @@ The user will guide the conversation. Ask clarifying questions if their request 
     }
   };
 
-  const handleDismiss = () => {
-    // Save current state before dismissing
-    saveSession(messages, sessionId);
-    // Clear agent runs so workflow page doesn't show stale agent output
-    useAgentStore.getState().clearRuns();
-    onDismiss();
-  };
-
   // Pre-compute turn numbers for streaming messages
   const streamTurnMap = useMemo(() => {
     const map = new Map<number, number>();
@@ -309,19 +298,6 @@ The user will guide the conversation. Ask clarifying questions if their request 
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
-      {/* Header with dismiss button */}
-      <div className="flex items-center justify-between border-b bg-background px-4 py-3">
-        <div>
-          <h2 className="text-lg font-semibold">Skill Refinement</h2>
-          <p className="text-sm text-muted-foreground">
-            Chat with an agent to refine your skill
-          </p>
-        </div>
-        <Button variant="ghost" size="icon" onClick={handleDismiss} aria-label="Close refinement chat">
-          <X className="size-4" />
-        </Button>
-      </div>
-
       {/* Agent status header — shown when an agent has been launched */}
       {currentAgentId && (
         <>

--- a/app/src/components/skill-card.tsx
+++ b/app/src/components/skill-card.tsx
@@ -31,7 +31,7 @@ function parseStepProgress(currentStep: string | null): number {
   const match = currentStep.match(/step\s*(\d+)/i)
   if (match) {
     const stepIndex = Number(match[1])
-    return Math.min(Math.round(((stepIndex + 1) / 8) * 100), 100)
+    return Math.min(Math.round(((stepIndex + 1) / 9) * 100), 100)
   }
   if (/completed/i.test(currentStep)) return 100
   if (/initialization/i.test(currentStep)) return 5

--- a/app/src/stores/workflow-store.ts
+++ b/app/src/stores/workflow-store.ts
@@ -76,6 +76,12 @@ const defaultSteps: WorkflowStep[] = [
     description: "Generate and evaluate test prompts",
     status: "pending",
   },
+  {
+    id: 8,
+    name: "Refine Skill",
+    description: "Chat with an agent to review, iterate, and polish the skill output",
+    status: "pending",
+  },
 ];
 
 export const useWorkflowStore = create<WorkflowState>((set) => ({
@@ -123,7 +129,7 @@ export const useWorkflowStore = create<WorkflowState>((set) => ({
   loadWorkflowState: (completedStepIds) =>
     set((state) => {
       // Filter out step IDs that no longer exist in the workflow (e.g. the
-      // removed Package step 8, or any higher IDs from legacy data).
+      // legacy Package step or any higher IDs from old workflow data).
       const validStepIds = new Set(state.steps.map((s) => s.id));
       const filtered = completedStepIds.filter((id) => validStepIds.has(id));
 


### PR DESCRIPTION
## Summary
- Adds "Refine Skill" as step 8 (the final workflow step) — an open-ended chat where users can iterate on their skill output with an agent
- Moves RefinementChat from a dismissible overlay to a first-class workflow step with Mark Complete and Skip buttons
- Updates step count from 8 to 9 across the workflow store, skill card progress calculation, Rust backend cleanup range, and all related tests
- Removes the dismiss/close button and header from RefinementChat since it's now embedded in the workflow layout

## Test plan
- [ ] Verify the workflow sidebar shows 9 steps with "Refine Skill" as the last
- [ ] Complete steps 0-7 and confirm step 8 renders the RefinementChat component
- [ ] Test Mark Complete and Skip buttons on the refinement step
- [ ] Verify skill card progress percentages updated (e.g., step 3 = 44% instead of 50%)
- [ ] Run `cargo test` for Rust backend changes
- [ ] Run `npm test` for frontend test changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)