### PR TITLE
VD-401: Move agent output logs to per-skill logs folder

### DIFF
--- a/CLAUDE-APP.md
+++ b/CLAUDE-APP.md
@@ -145,13 +145,13 @@ Agents run via the **Claude Agent SDK** in a Node.js sidecar process. This gives
 
 ### Agent logging
 
-The sidecar creates `.agent-logs/<agent_id>.jsonl` files in the workspace directory. Each log file contains:
+The sidecar creates log files under each skill's `logs/` directory: `{workspace}/{skill-name}/logs/{step_label}-{timestamp}.jsonl`. For example: `~/.vibedata/my-skill/logs/step0-research-concepts-2026-02-11T09-30-00.jsonl`. Each log file contains:
 - First line: redacted config (API key replaced with `[REDACTED]`)
 - Subsequent lines: raw JSON messages from stdout (same as Tauri events)
 - stderr lines logged as `{"type":"stderr","content":"..."}`
 - Final line: `{"type":"agent-exit","success":true|false}`
 
-Useful for debugging agent runs: `tail -f .agent-logs/<agent_id>.jsonl`
+Useful for debugging agent runs: `tail -f ~/.vibedata/my-skill/logs/step0-research-concepts-*.jsonl`
 
 ### Sidecar config (passed as CLI argument)
 
@@ -222,6 +222,7 @@ The app replicates the plugin workflow. Each step is a state in the workflow sta
     SKILL.md                       # Main skill file
     references/                    # Deep-dive reference files
     <skill-name>.skill             # Packaged zip
+    logs/                          # Agent output logs ({step_label}-{timestamp}.jsonl)
     context/                       # Intermediate working files
       clarifications-concepts.md
       clarifications-patterns.md

--- a/app/src-tauri/src/commands/agent.rs
+++ b/app/src-tauri/src/commands/agent.rs
@@ -13,6 +13,8 @@ pub async fn start_agent(
     allowed_tools: Option<Vec<String>>,
     max_turns: Option<u32>,
     session_id: Option<String>,
+    skill_name: String,
+    step_label: String,
 ) -> Result<String, String> {
     let (api_key, extended_context) = {
         let conn = db.0.lock().map_err(|e| e.to_string())?;
@@ -41,7 +43,7 @@ pub async fn start_agent(
         agent_name: None,
     };
 
-    sidecar::spawn_sidecar(agent_id.clone(), config, state.inner().clone(), app).await?;
+    sidecar::spawn_sidecar(agent_id.clone(), config, state.inner().clone(), app, skill_name, step_label).await?;
 
     Ok(agent_id)
 }

--- a/app/src-tauri/src/commands/workflow.rs
+++ b/app/src-tauri/src/commands/workflow.rs
@@ -555,7 +555,8 @@ pub async fn run_review_step(
         agent_name: None,
     };
 
-    sidecar::spawn_sidecar(agent_id.clone(), config, state.inner().clone(), app).await?;
+    let step_label = format!("review-step{}", step_id);
+    sidecar::spawn_sidecar(agent_id.clone(), config, state.inner().clone(), app, skill_name, step_label).await?;
     Ok(agent_id)
 }
 
@@ -625,7 +626,8 @@ pub async fn run_workflow_step(
         agent_name: Some(agent_name),
     };
 
-    sidecar::spawn_sidecar(agent_id.clone(), config, state.inner().clone(), app).await?;
+    let step_label = format!("step{}-{}", step_id, step.name);
+    sidecar::spawn_sidecar(agent_id.clone(), config, state.inner().clone(), app, skill_name, step_label).await?;
     Ok(agent_id)
 }
 

--- a/app/src/__tests__/components/reasoning-chat.test.tsx
+++ b/app/src/__tests__/components/reasoning-chat.test.tsx
@@ -293,6 +293,8 @@ describe("ReasoningChat — conflict detection and resolution flow", () => {
       ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "Task"],
       100,
       "session-123",
+      "saas-revenue",
+      "step4-reasoning",
     );
   });
 
@@ -437,6 +439,8 @@ describe("ReasoningChat — conflict detection and resolution flow", () => {
       expect.any(Array),
       100,
       "session-123",
+      "saas-revenue",
+      "step4-reasoning",
     );
   });
 
@@ -468,6 +472,8 @@ describe("ReasoningChat — conflict detection and resolution flow", () => {
       expect.any(Array),
       100,
       "session-123",
+      "saas-revenue",
+      "step4-reasoning",
     );
   });
 
@@ -503,6 +509,8 @@ describe("ReasoningChat — conflict detection and resolution flow", () => {
       expect.any(Array),
       100,
       "session-123",
+      "saas-revenue",
+      "step4-reasoning",
     );
   });
 });

--- a/app/src/__tests__/components/refinement-chat.test.tsx
+++ b/app/src/__tests__/components/refinement-chat.test.tsx
@@ -225,6 +225,8 @@ describe("RefinementChat", () => {
         ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "Task"],
         50,
         undefined, // No session ID yet
+        "test-skill",
+        "chat",
       );
     });
 
@@ -277,6 +279,8 @@ describe("RefinementChat", () => {
         ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "Task"],
         50,
         "session-123", // Session ID from first turn
+        "test-skill",
+        "chat",
       );
     });
   });

--- a/app/src/components/reasoning-chat.tsx
+++ b/app/src/components/reasoning-chat.tsx
@@ -298,6 +298,8 @@ export function ReasoningChat({
         ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "Task"],
         100,
         sessionId,
+        skillName,
+        "step4-reasoning",
       );
 
       agentStartRun(agentId, "opus");

--- a/app/src/components/refinement-chat.tsx
+++ b/app/src/components/refinement-chat.tsx
@@ -245,6 +245,8 @@ The user will guide the conversation. Ask clarifying questions if their request 
         ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "Task"],
         50,
         sessionId,
+        skillName,
+        "chat",
       );
 
       agentStartRun(agentId, "sonnet");

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -50,7 +50,9 @@ export const startAgent = (
   allowedTools?: string[],
   maxTurns?: number,
   sessionId?: string,
-) => invoke<string>("start_agent", { agentId, prompt, model, cwd, allowedTools, maxTurns, sessionId });
+  skillName?: string,
+  stepLabel?: string,
+) => invoke<string>("start_agent", { agentId, prompt, model, cwd, allowedTools, maxTurns, sessionId, skillName: skillName ?? "unknown", stepLabel: stepLabel ?? "unknown" });
 
 // --- Workflow ---
 


### PR DESCRIPTION
## Summary
- Move agent logs from shared `.agent-logs/` directory to per-skill `{skill-name}/logs/{step_label}-{timestamp}.jsonl`
- Thread `skill_name` and `step_label` through sidecar, workflow, and agent commands so log files are descriptively named
- Add unit tests for slug generation, log path construction, file creation, API key redaction, and skill deletion cleanup

## Test plan
- [ ] Verify agent logs are created under `{skill-name}/logs/` during a workflow run
- [ ] Confirm log filenames include the step label and timestamp (e.g., `step0-research-concepts-2026-02-11T09-30-00.jsonl`)
- [ ] Run `cargo test` to validate new Rust unit tests pass
- [ ] Run frontend tests (`reasoning-chat`, `refinement-chat`) to verify updated `startAgent` signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)