### PR TITLE
VD-380: Fix stale Step 8 references — Package → Refine Skill

### DIFF
--- a/CLAUDE-APP.md
+++ b/CLAUDE-APP.md
@@ -209,7 +209,7 @@ The app replicates the plugin workflow. Each step is a state in the workflow sta
 5. **Build** — creates SKILL.md + reference files
 6. **Validate** — checks against best practices
 7. **Test** — generates and evaluates test prompts
-8. **Package** — creates `.skill` zip archive
+8. **Refine Skill** — interactive chat to review, iterate, and polish the skill
 
 ## Data Model (repo structure)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,11 @@ Shared agents in `agents/shared/`:
 | 5 | 6 | Build |
 | 6 | 7 | Validate |
 | 7 | 8 | Test |
-| 8 | 9 | Package |
+| 8 | 9 | Refine Skill |
 
 The only difference is the Init step — the plugin collects skill name and type via conversation, the app uses the new-skill dialog before the workflow starts.
+
+> **Note:** The app's "Package" action was moved from the workflow to a dashboard right-click action (VD-387). The plugin still has Package as Step 9.
 
 ## Custom Skills
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The app combines parallel research + merge into a single orchestrator step and c
 | **5** | Build skill files | Review structure |
 | **6** | Validate against best practices | Review log |
 | **7** | Test — generate and evaluate test prompts | Review results |
-| **8** | Package into `.skill` zip | Done |
+| **8** | Refine Skill | Done |
 
 ## Repo Structure
 


### PR DESCRIPTION
## Summary

- Update `CLAUDE.md`, `CLAUDE-APP.md`, and `README.md` to reflect that the desktop app's Step 8 is now "Refine Skill" (changed in VD-388)
- Add note in `CLAUDE.md` that app packaging moved to dashboard right-click action (VD-387)
- Plugin docs (`CLAUDE-PLUGIN.md`) unchanged — Plugin Step 9 is still Package

## Test plan

- [x] Verify CLAUDE.md workflow table shows "Refine Skill" for app Step 8
- [x] Verify CLAUDE.md has VD-387 packaging note
- [x] Verify CLAUDE-APP.md shows "Refine Skill" description
- [x] Verify README.md table shows "Refine Skill"
- [x] Verify CLAUDE-PLUGIN.md is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)