### PR TITLE
VD-449: Generate AI-summarized release notes for GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,20 +226,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          CURRENT_TAG="v${RELEASE_VERSION}"
-
           # Fetch all tags to ensure we have the full history
           git fetch --tags
 
           # Determine the previous tag (most recent tag before the current one)
           PREVIOUS_TAG=$(git tag --sort=-creatordate | grep '^v' | head -2 | tail -1)
 
-          # Build the commit log
-          if [ -z "$PREVIOUS_TAG" ] || [ "$PREVIOUS_TAG" = "$CURRENT_TAG" ]; then
-            # No previous tag — use all commits from root
-            COMMITS=$(git log --oneline --format="%s" "$CURRENT_TAG" 2>/dev/null || git log --oneline --format="%s")
+          # Build the commit log (use HEAD since the release tag doesn't exist yet)
+          if [ -z "$PREVIOUS_TAG" ]; then
+            # No previous tag — use all commits
+            COMMITS=$(git log --oneline --format="%s" HEAD)
           else
-            COMMITS=$(git log --oneline --format="%s" "${PREVIOUS_TAG}..${CURRENT_TAG}" 2>/dev/null || git log --oneline --format="%s" "${PREVIOUS_TAG}..HEAD")
+            COMMITS=$(git log --oneline --format="%s" "${PREVIOUS_TAG}..HEAD")
           fi
 
           if [ -z "$COMMITS" ]; then
@@ -266,7 +264,7 @@ jobs:
                 }]
               }')
 
-            RESPONSE=$(curl -s --max-time 30 \
+            RESPONSE=$(curl -s --max-time 60 \
               -H "x-api-key: ${ANTHROPIC_API_KEY}" \
               -H "anthropic-version: 2023-06-01" \
               -H "content-type: application/json" \


### PR DESCRIPTION
Fixes VD-449

## Summary

Adds automatic AI-generated release notes to the GitHub release workflow. During a release, the workflow summarizes git commits between tags using Claude Haiku and includes the result as the release body. Falls back to a plain commit list if the API call fails.

## Changes

- Added checkout step with full history (`fetch-depth: 0`) to the `release` job
- Added "Generate release notes" step that:
  - Finds commits between the previous tag and HEAD
  - Calls Claude API (Haiku) to generate user-facing summaries grouped into Highlights / New / Improved / Fixed / Breaking Changes
  - Falls back to bullet-list commit subjects if API fails or key isn't configured
- Release notes passed as `body` to `softprops/action-gh-release`
- Uses `jq --arg` for safe JSON construction (handles special chars in commit messages)
- Requires `ANTHROPIC_API_KEY` GitHub secret (graceful degradation if missing)

## Test Coverage

- CI-only change — no local tests applicable
- Script handles edge cases: no previous tag, empty commits, API failure, missing API key

## Acceptance Criteria

- [x] Each GitHub release includes a human-readable summary of what changed
- [x] Release notes are written in end-user language (no developer jargon)
- [x] Changes are grouped by category (features, improvements, fixes)
- [x] LLM failure does not block the release — falls back to commit list
- [x] No manual maintenance required (fully automated in CI)