### PR TITLE
VD-459: add Edit Tags option to skill card context menu

### DIFF
--- a/app/src/__tests__/components/edit-tags-dialog.test.tsx
+++ b/app/src/__tests__/components/edit-tags-dialog.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockInvoke, resetTauriMocks } from "@/test/mocks/tauri";
+import { toast } from "sonner";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  Toaster: () => null,
+}));
+
+import EditTagsDialog from "@/components/edit-tags-dialog";
+import type { SkillSummary } from "@/lib/types";
+
+const sampleSkill: SkillSummary = {
+  name: "sales-pipeline",
+  domain: "sales",
+  current_step: "Step 3",
+  status: "in_progress",
+  last_modified: new Date().toISOString(),
+  tags: ["analytics", "crm"],
+  skill_type: null,
+};
+
+describe("EditTagsDialog", () => {
+  beforeEach(() => {
+    resetTauriMocks();
+    vi.mocked(toast.success).mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("renders dialog title when open", () => {
+    render(
+      <EditTagsDialog
+        skill={sampleSkill}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSaved={vi.fn()}
+        availableTags={[]}
+      />
+    );
+    expect(screen.getByText("Edit Tags")).toBeInTheDocument();
+  });
+
+  it("renders skill name in description", () => {
+    render(
+      <EditTagsDialog
+        skill={sampleSkill}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSaved={vi.fn()}
+        availableTags={[]}
+      />
+    );
+    expect(screen.getByText("sales-pipeline")).toBeInTheDocument();
+  });
+
+  it("does not render when open is false", () => {
+    render(
+      <EditTagsDialog
+        skill={sampleSkill}
+        open={false}
+        onOpenChange={vi.fn()}
+        onSaved={vi.fn()}
+        availableTags={[]}
+      />
+    );
+    expect(screen.queryByText("Edit Tags")).not.toBeInTheDocument();
+  });
+
+  it("shows existing tags as badges", () => {
+    render(
+      <EditTagsDialog
+        skill={sampleSkill}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSaved={vi.fn()}
+        availableTags={[]}
+      />
+    );
+    expect(screen.getByText("analytics")).toBeInTheDocument();
+    expect(screen.getByText("crm")).toBeInTheDocument();
+  });
+
+  it("has Cancel and Save buttons", () => {
+    render(
+      <EditTagsDialog
+        skill={sampleSkill}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSaved={vi.fn()}
+        availableTags={[]}
+      />
+    );
+    expect(screen.getByRole("button", { name: /Cancel/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Save/i })).toBeInTheDocument();
+  });
+
+  it("calls onOpenChange(false) when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <EditTagsDialog
+        skill={sampleSkill}
+        open={true}
+        onOpenChange={onOpenChange}
+        onSaved={vi.fn()}
+        availableTags={[]}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Cancel/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("calls updateSkillTags and callbacks on successful save", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onSaved = vi.fn();
+    mockInvoke.mockResolvedValue(undefined);
+
+    render(
+      <EditTagsDialog
+        skill={sampleSkill}
+        open={true}
+        onOpenChange={onOpenChange}
+        onSaved={onSaved}
+        availableTags={[]}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("update_skill_tags", {
+        skillName: "sales-pipeline",
+        tags: ["analytics", "crm"],
+      });
+    });
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+    expect(onSaved).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith("Tags updated");
+  });
+
+  it("shows error toast on failed save", async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockRejectedValue(new Error("DB error"));
+
+    render(
+      <EditTagsDialog
+        skill={sampleSkill}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSaved={vi.fn()}
+        availableTags={[]}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Failed to update tags: DB error",
+        { duration: Infinity },
+      );
+    });
+  });
+
+  it("handles null skill gracefully", () => {
+    render(
+      <EditTagsDialog
+        skill={null}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSaved={vi.fn()}
+        availableTags={[]}
+      />
+    );
+    expect(screen.getByText("Edit Tags")).toBeInTheDocument();
+  });
+});

--- a/app/src/components/edit-tags-dialog.tsx
+++ b/app/src/components/edit-tags-dialog.tsx
@@ -1,0 +1,96 @@
+import { useState, useEffect } from "react"
+import { toast } from "sonner"
+import { Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import TagInput from "@/components/tag-input"
+import { updateSkillTags } from "@/lib/tauri"
+import type { SkillSummary } from "@/lib/types"
+
+interface EditTagsDialogProps {
+  skill: SkillSummary | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSaved: () => void
+  availableTags: string[]
+}
+
+export default function EditTagsDialog({
+  skill,
+  open,
+  onOpenChange,
+  onSaved,
+  availableTags,
+}: EditTagsDialogProps) {
+  const [tags, setTags] = useState<string[]>([])
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (open && skill) {
+      setTags([...skill.tags])
+    } else if (!open) {
+      setTags([])
+      setSaving(false)
+    }
+  }, [open, skill])
+
+  const handleSave = async () => {
+    if (!skill) return
+    setSaving(true)
+    try {
+      await updateSkillTags(skill.name, tags)
+      toast.success("Tags updated")
+      onOpenChange(false)
+      onSaved()
+    } catch (err) {
+      toast.error(
+        `Failed to update tags: ${err instanceof Error ? err.message : String(err)}`,
+        { duration: Infinity },
+      )
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Tags</DialogTitle>
+          <DialogDescription>
+            Update tags for{" "}
+            <span className="font-medium text-foreground">
+              {skill?.name}
+            </span>
+          </DialogDescription>
+        </DialogHeader>
+        <TagInput
+          tags={tags}
+          onChange={setTags}
+          suggestions={availableTags}
+          disabled={saving}
+        />
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving && <Loader2 className="size-4 animate-spin" />}
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/src/components/skill-card.tsx
+++ b/app/src/components/skill-card.tsx
@@ -11,10 +11,11 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
 import { Progress } from "@/components/ui/progress"
-import { Download, Play, Trash2 } from "lucide-react"
+import { Download, Play, Tag, Trash2 } from "lucide-react"
 import type { SkillSummary, SkillType } from "@/lib/types"
 import { SKILL_TYPE_LABELS, SKILL_TYPE_COLORS } from "@/lib/types"
 import { cn } from "@/lib/utils"
@@ -24,6 +25,7 @@ interface SkillCardProps {
   onContinue: (skill: SkillSummary) => void
   onDelete: (skill: SkillSummary) => void
   onDownload?: (skill: SkillSummary) => void
+  onEditTags?: (skill: SkillSummary) => void
 }
 
 function parseStepProgress(currentStep: string | null): number {
@@ -117,6 +119,7 @@ export default function SkillCard({
   onContinue,
   onDelete,
   onDownload,
+  onEditTags,
 }: SkillCardProps) {
   const progress = parseStepProgress(skill.current_step)
   const relativeTime = formatRelativeTime(skill.last_modified)
@@ -185,6 +188,11 @@ export default function SkillCard({
         </Card>
       </ContextMenuTrigger>
       <ContextMenuContent>
+        <ContextMenuItem onSelect={() => onEditTags?.(skill)}>
+          <Tag className="size-4" />
+          Edit Tags
+        </ContextMenuItem>
+        <ContextMenuSeparator />
         <ContextMenuItem
           disabled={!canDownload}
           onSelect={() => canDownload && onDownload?.(skill)}

--- a/app/src/pages/dashboard.tsx
+++ b/app/src/pages/dashboard.tsx
@@ -26,6 +26,7 @@ import {
 import SkillCard from "@/components/skill-card"
 import NewSkillDialog from "@/components/new-skill-dialog"
 import DeleteSkillDialog from "@/components/delete-skill-dialog"
+import EditTagsDialog from "@/components/edit-tags-dialog"
 import TagFilter from "@/components/tag-filter"
 import { OnboardingDialog } from "@/components/onboarding-dialog"
 import { useSettingsStore } from "@/stores/settings-store"
@@ -38,6 +39,7 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true)
   const [workspacePath, setWorkspacePath] = useState("")
   const [deleteTarget, setDeleteTarget] = useState<SkillSummary | null>(null)
+  const [editTagsTarget, setEditTagsTarget] = useState<SkillSummary | null>(null)
   const [searchQuery, setSearchQuery] = useState("")
   const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [selectedTypes, setSelectedTypes] = useState<string[]>([])
@@ -296,10 +298,21 @@ export default function DashboardPage() {
               onContinue={handleContinue}
               onDelete={setDeleteTarget}
               onDownload={handleDownload}
+              onEditTags={setEditTagsTarget}
             />
           ))}
         </div>
       )}
+
+      <EditTagsDialog
+        skill={editTagsTarget}
+        open={editTagsTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditTagsTarget(null)
+        }}
+        onSaved={() => { loadSkills(); loadTags(); }}
+        availableTags={availableTags}
+      />
 
       <DeleteSkillDialog
         skill={deleteTarget}

--- a/app/tests/TEST_MANIFEST.md
+++ b/app/tests/TEST_MANIFEST.md
@@ -51,6 +51,7 @@ Maps every source file to its tests across all layers. Use this to determine whi
 | `src/components/skill-card.tsx` | -- | `components/skill-card.test.tsx` (34) | `@dashboard` |
 | `src/components/new-skill-dialog.tsx` | -- | `components/new-skill-dialog.test.tsx` (19) | `@dashboard` |
 | `src/components/delete-skill-dialog.tsx` | -- | `components/delete-skill-dialog.test.tsx` (8) | `@dashboard` |
+| `src/components/edit-tags-dialog.tsx` | -- | `components/edit-tags-dialog.test.tsx` (9) | `@dashboard` |
 | `src/components/feedback-dialog.tsx` | -- | `components/feedback-dialog.test.tsx` (21) | `@workflow` |
 | `src/components/reasoning-chat.tsx` | -- | `components/reasoning-chat.test.tsx` (16) | `@workflow` |
 | `src/components/refinement-chat.tsx` | -- | `components/refinement-chat.test.tsx` (11) | `@workflow` |


### PR DESCRIPTION
## Summary

- Adds an "Edit Tags" option to the skill card's right-click context menu on the dashboard
- Opens a dialog with `TagInput` pre-populated with existing tags and autocomplete suggestions
- Saves tag changes via the existing `update_skill_tags` Rust command and refreshes the dashboard

Fixes VD-459

## Test plan

- [x] Unit tests pass (43/43 — skill-card + edit-tags-dialog)
- [ ] Right-click a skill card → "Edit Tags" appears in context menu
- [ ] Opening shows current tags pre-populated
- [ ] Add/remove tags, save → tags persist and card updates immediately
- [ ] Cancel without saving → no changes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)