### PR TITLE
VD-460: fix unused import breaking release builds

### DIFF
--- a/app/src/__tests__/pages/workflow.test.tsx
+++ b/app/src/__tests__/pages/workflow.test.tsx
@@ -68,7 +68,7 @@ vi.mock("@/components/step-rerun-chat", () => ({
 
 // Import after mocks
 import WorkflowPage from "@/pages/workflow";
-import { getWorkflowState, saveWorkflowState, getArtifactContent, saveArtifactContent, readFile, runWorkflowStep, resetWorkflowStep, cleanupSkillSidecar, hasStepArtifacts } from "@/lib/tauri";
+import { getWorkflowState, saveWorkflowState, getArtifactContent, saveArtifactContent, readFile, runWorkflowStep, resetWorkflowStep, cleanupSkillSidecar } from "@/lib/tauri";
 
 describe("WorkflowPage — agent completion lifecycle", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Remove unused `hasStepArtifacts` import from `workflow.test.tsx` that caused TS6133 error
- This broke `npm run build` (Tauri's `beforeBuildCommand`) on both macOS and Windows CI
- Also deleted the stale `v0.9.2` draft release that was blocking re-runs

## Test plan
- [ ] `npm run build` succeeds in `app/`
- [ ] Re-run release pipeline for v0.9.2

Fixes VD-460

🤖 Generated with [Claude Code](https://claude.com/claude-code)